### PR TITLE
Latinize Andre Gloukhmantchouk properly

### DIFF
--- a/public/app/templates/about.ejs
+++ b/public/app/templates/about.ejs
@@ -71,7 +71,7 @@
         <li>
             <img class="speaker-photo" src="images/speakers/andre_gloukhmantchouk.jpg" alt="Andrew Gluhamanchuk"/>
 
-            <h3>Andrew Gluhamanchuk</h3>
+            <h3>Andre Gloukhmantchouk</h3>
         </li>
         <li>
             <img class="speaker-photo" src="images/speakers/dzmitry_varabei.jpg" alt="Dzmitry Varabei"/>


### PR DESCRIPTION
Properly latinize Andre (see his Skype name) 😸 

Dude, your name should be in string benchmarks

@Andre-Gl @dzmitry-varabei @R1ZZU 